### PR TITLE
Updates Card design

### DIFF
--- a/src/components/Card.js
+++ b/src/components/Card.js
@@ -1,48 +1,72 @@
 import React, { useState } from 'react'; 
-import ReactCardFlip from 'react-card-flip'; 
+//*material UI hook wraps component with styles (CardStyles.js)
 import { withStyles } from '@material-ui/core/styles'; 
-
-import { Card, CardContent } from '@material-ui/core'; 
-import { Typography } from '@material-ui/core'; 
-
 import styles from '../styles/CardStyles'; 
 
+import ReactCardFlip from 'react-card-flip'; 
+//* material UI components 
+import { 
+    Avatar, 
+    Button, 
+    Card, 
+    CardActions, 
+    CardContent, 
+    CardHeader, 
+    Typography 
+} from '@material-ui/core'; 
+
+
 const FlashCard = ({ card, classes }) => {
-    // isFlipped controls the react-card-flip status 
-    // False on start 
+    // isFlipped state controls the react-card-flip component, false on start 
     const [isFlipped, setIsFlipped] = useState(false); 
 
-    // Now we need a function (a click handler) to update isFlipped state 
+    // click handler - toggles the isFlipped state, flipping the card to reveal the text on the back
     const flipCard = (event) => {
         event.preventDefault(); 
         setIsFlipped(!isFlipped); 
     }
-
-    // Now we must connect the ReactFlipCard component to the isFlipped State, so that it will know at any time what the state value is 
-    // flipDirection is a react-flip-card library property that specifies how the card flips
+    //* isFlipped is connected to the ReactCardFlip component - the parents of two separate containing divs - the front and the back.
+    //* front and back of each each is its own Card component - the sides have slightly different functionality
+    //* each "face" of the card is connected to the flipCard handler fn
     return (
-        <Card className={classes.root}>
+        <React.Fragment>
+        
             <ReactCardFlip isFlipped={isFlipped} flipDirection="vertical">
-                {/* 2 main DIVS will go inside the parent ReactCardFlip component - they are the front and back respectively */}
-                {/*//* can I use MATERIAL UI with this library? Try replacing divs in a moment, perhaps it can be 2 child elements*/}
-                <CardContent onClick={flipCard}>
-                        <Typography variant="h4" component="p">{card.card_front}</Typography>
-                </CardContent>
+                <Card onClick={flipCard} className={classes.root} variant="outlined">
+                    <CardHeader
+                        avatar={<Avatar className={classes.small} aria-label="subject">CSS</Avatar>}
+                        className={classes.header}
+                        title="Deck Subject Here"
+                    />
+                    <CardContent className={classes.content}>
+                        <Typography className={classes.text} variant="h4">{card.card_front}</Typography>
+                    </CardContent>
+                    <CardActions>
+                        <Button size="small" variant="outlined" color="secondary">Delete</Button>
+                        <Button size="small" variant="outlined">Edit</Button>
+                    </CardActions>
+                </Card>
 
-                <CardContent onClick={flipCard}>
-                        <Typography variant="h5" component="p">{card.card_back}</Typography>
-                </CardContent>
+                <Card onClick={flipCard}>
+                    <CardContent className={classes.content}>
+                        <Typography className={classes.text} variant="h4">{card.card_back}</Typography>
+                    </CardContent>
+                    <CardActions>
+                        <Button size="small" variant="outlined">Edit</Button>
+                    </CardActions>
+                </Card>
             </ReactCardFlip>
-        </Card>
+
+        </React.Fragment>
     ); 
 }
 
 export default withStyles(styles)(FlashCard); 
 
-// ! Problem - when the cards are flipped (clicked) they change width, and cause their parent to collapse - it's an ugly flick in the UI 
-// I think this is happening because each side of the cards are displaying differently sized text elements. 
-// ? I wonder if I can add the `fixed` flag to the Card component (from Material UI) above to prevent the resizing 
-// ? Or if I need to make the content on each side the same size... adjust for the card size and content area... or other fixes I could apply 
+/* --------------------------- Card Design Update --------------------------- */
+//* Now that the build has seen some progress, the shape of how things will fit together is starting to emerge. 
+//* 3/6/21 - Updating the cards to appear more like a flashcard - adding edit and delete button [for now these are non-functional]
+//TODO - add an Collapse MUI element to the back of the card - this will render "notes" from the card (if it has any)
 
 //TODO - Answer the following...
 //? How to use pagination to show one card at a time

--- a/src/components/Cards.js
+++ b/src/components/Cards.js
@@ -1,22 +1,11 @@
 import React, { useState } from 'react'; 
 
 import Paper from '@material-ui/core/Paper'; 
-
-//TODO - this state needs to be lifted 🔽
-// eventually it will be coming from my API 
-import data from '../resources/CardsData'; 
-
+//* consider making this just a react Frgament, rather than another div in the code 
 import FlashCard from './Card'; 
 
-//? What will I need from Material UI? 
-// Paper, for the main page 
-//? How will the cards be done? 
-// I've used a third party library in the past that might be useful here, especially for 'study mode' - not sure how I'll implement a game yet 
-//* I'll be adding React-Card-Flip to the project and trying it out... I don't know if it will work with Material UI though 🤔 
-// Whatever, we're trying it because it's the next logical step. Don't overthink this too much. Get a decent full stack project up. 
-
-//TODO: Component shift 
-// consider rendering the cards in a BOX component? This might be a more sound option than Paper. (Box is a div) - or use a React.Fragment
+//TODO - this cards state needs to be lifted to Dashboard
+import data from '../resources/CardsData'; 
 
 function Cards(){
     const [cards] = useState(data); 
@@ -35,11 +24,9 @@ export default Cards;
 /* -------------------------------------------------------------------------- */
 /*                                 About Cards                                */
 /* 
-    //Cards is a parent component, it will hold state, and actions concerned with it,
-    //and pass it to the Card child component 
-
-    * Update: Cards will *not* be concerned with state, it will only be rendered in the Dashboard. 
-    The Dashboard will be the "top level" component for Cards data 
-    The Cards component is now just concerned with displaying Card children
+    Parent: Dashboard
+    Direct Children: FlashCards
+    
+    Cards is a view Component that passes state to the child FlashCard component
 */
 /* -------------------------------------------------------------------------- */

--- a/src/styles/CardStyles.js
+++ b/src/styles/CardStyles.js
@@ -1,12 +1,29 @@
 const styles = theme => ({
     // root describes parent Card
     root: {
-        width: "45%", 
-        margin: "0 auto", 
-        padding: "1%"
+        boxShadow: "5px 5px 5px lightgrey"
     }, 
-    card: {
-        marginTop: "1%"
+    // styles for the colored header on the Card component 
+    // I'd like to make this dynamic at some point, with decks getting different colors 
+    // essentially color coding
+    header: {
+        display: "flex",
+        color: "white",
+        backgroundColor: theme.palette.primary.dark,
+    }, 
+    // styles for Avatar - round deck identifier 
+    small: {
+        width: theme.spacing(4.5),
+        height: theme.spacing(4.5),
+        fontSize: "1rem",
+        backgroundColor: theme.palette.primary.light,
+    }, 
+    content: {
+        textAlign: "center",
+    }, 
+    // margin around the internal text of the card - the question and answer 
+    text: {
+        margin: theme.spacing(5), 
     }
 }); 
 


### PR DESCRIPTION
Refactored the Card component. Previously it was a simple two sided card, with text only.

The card now features a CardHeader (MUI) that will show the card's topic (the subject, or deck it's in - all ways to say the same thing, I think). Only on the front of the card.

Also applies a colored banner to the top of the card. Eventually I need to find a way to programmatically make this color dynamic - allowing users to assign colors to topics and color code their studying.

Additionally, delete and edit Buttons (MUI) (non-functional) have been added to each card. Only edit on back.