### PR TITLE
Styles/grid component

### DIFF
--- a/src/components/Decks/Deck.js
+++ b/src/components/Decks/Deck.js
@@ -12,8 +12,9 @@ import { withStyles } from '@material-ui/core/styles';
 import styles from './DeckStyles';
 
 const Deck = ({ classes, deck }) => {
+  const itemClass = `grid-item ${classes.root}`;
   return (
-    <Card className={classes.root}>
+    <Card className={itemClass}>
       <CardContent>
         <Typography className={classes.title}>{deck.name}</Typography>
       </CardContent>

--- a/src/components/Decks/Decks.js
+++ b/src/components/Decks/Decks.js
@@ -2,6 +2,8 @@ import React from 'react';
 import { Container, Typography } from '@material-ui/core';
 
 import Deck from './Deck';
+import Grid from '../../layoutComponents/Grid';
+import SubHeader from '../../layoutComponents/SubHeader';
 
 // this component will be passed a piece of state from App, a decks array
 // it will visualize the decks here - i will need to make them into Routes that will render the cards in the deck, and more information
@@ -13,10 +15,8 @@ const Decks = ({ decks }) => {
 
   return (
     <Container>
-      <Typography>Recent Decks:</Typography>
-      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr' }}>
-        {renderedItems}
-      </div>
+      <SubHeader component={'h3'}>Recent Decks</SubHeader>
+      <Grid>{renderedItems}</Grid>
     </Container>
   );
 };

--- a/src/components/Decks/Decks.js
+++ b/src/components/Decks/Decks.js
@@ -15,7 +15,9 @@ const Decks = ({ decks }) => {
 
   return (
     <Container>
-      <SubHeader component={'h3'}>Recent Decks</SubHeader>
+      <SubHeader options={{ variant: 'h5', component: 'h3' }}>
+        Recent Decks
+      </SubHeader>
       <Grid>{renderedItems}</Grid>
     </Container>
   );

--- a/src/components/Decks/Decks.js
+++ b/src/components/Decks/Decks.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Container, Typography } from '@material-ui/core';
+import { Container } from '@material-ui/core';
 
 import Deck from './Deck';
 import Grid from '../../layoutComponents/Grid';

--- a/src/layoutComponents/Grid/Grid.js
+++ b/src/layoutComponents/Grid/Grid.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import styles from './GridStyles';
+import { withStyles } from '@material-ui/core/styles';
+
+const Grid = (props) => {
+  const { classes } = props;
+  return <div className={classes.root}>{props.children}</div>;
+};
+
+export default withStyles(styles)(Grid);

--- a/src/layoutComponents/Grid/Grid.js
+++ b/src/layoutComponents/Grid/Grid.js
@@ -2,9 +2,8 @@ import React from 'react';
 import styles from './GridStyles';
 import { withStyles } from '@material-ui/core/styles';
 
-const Grid = (props) => {
-  const { classes } = props;
-  return <div className={classes.root}>{props.children}</div>;
+const Grid = ({ children, classes }) => {
+  return <div className={classes.root}>{children}</div>;
 };
 
 export default withStyles(styles)(Grid);

--- a/src/layoutComponents/Grid/GridStyles.js
+++ b/src/layoutComponents/Grid/GridStyles.js
@@ -1,0 +1,13 @@
+const styles = (theme) => ({
+  root: {
+    display: 'grid',
+    gridTemplateColumns: '1fr 1fr 1fr',
+    padding: '5%',
+
+    '& .grid-item': {
+      placeSelf: 'center',
+    },
+  },
+});
+
+export default styles;

--- a/src/layoutComponents/Grid/index.js
+++ b/src/layoutComponents/Grid/index.js
@@ -1,0 +1,1 @@
+export { default } from './Grid';

--- a/src/layoutComponents/SubHeader/SubHeader.js
+++ b/src/layoutComponents/SubHeader/SubHeader.js
@@ -3,8 +3,19 @@ import styles from './SubHeaderStyles';
 import { Typography } from '@material-ui/core';
 import { withStyles } from '@material-ui/styles';
 
-const SubHeader = ({ children, classes }) => {
-  return <Typography className={classes.root}>{children}</Typography>;
+const SubHeader = ({ children, classes, options }) => {
+  return (
+    <Typography
+      variant={options.variant}
+      component={options.component}
+      className={classes.root}
+    >
+      {children}
+    </Typography>
+  );
 };
 
 export default withStyles(styles)(SubHeader);
+
+// this component needs to take in a few options so that we can fully take advantage of mui's typography and header hierarchy (accessibility!)
+// receive an options object?

--- a/src/layoutComponents/SubHeader/SubHeader.js
+++ b/src/layoutComponents/SubHeader/SubHeader.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import styles from './SubHeaderStyles';
+import { Typography } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
+
+const SubHeader = ({ children, classes }) => {
+  return <Typography className={classes.root}>{children}</Typography>;
+};
+
+export default withStyles(styles)(SubHeader);

--- a/src/layoutComponents/SubHeader/SubHeaderStyles.js
+++ b/src/layoutComponents/SubHeader/SubHeaderStyles.js
@@ -1,0 +1,7 @@
+const styles = (theme) => ({
+  root: {
+    color: 'white',
+  },
+});
+
+export default styles;

--- a/src/layoutComponents/SubHeader/index.js
+++ b/src/layoutComponents/SubHeader/index.js
@@ -1,0 +1,1 @@
+export { default } from './SubHeader';


### PR DESCRIPTION
Adds two reusable styled components to the project. 

First a Grid that creates a three column grid with items centered in their cells. I will be adding responsive breakpoints to this, and can easily reuse it when I build the Decks control center, and so on. 

The SubHeader is basically for any header/not header I'll need to separate different sections of the UI. This way I can easily reuse the same styles and update them all at once. 